### PR TITLE
Gracefully handle the case where percy agent is not running

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -14,6 +14,11 @@ Cypress.Commands.add('percySnapshot', (name: string, options: any = {}) => {
 
   cy.document().then((doc: Document) => {
     options.document = doc
-    percyAgentClient.snapshot(name, options)
+
+    try {
+      percyAgentClient.snapshot(name, options)
+    } catch (e) {
+      cy.log('WARNING! percy is not started. See https://docs.percy.io for help.')
+    }
   })
 })


### PR DESCRIPTION
Works in combination with https://github.com/percy/percy-agent/pull/9 and resolves #3 