### PR TITLE
Fix snapshotting of the live Buildkite site by turning on JavaScript

### DIFF
--- a/cypress/integration/sdk_spec.js
+++ b/cypress/integration/sdk_spec.js
@@ -52,7 +52,7 @@ describe('@percy/cypress', function() {
 
     it('snapshots website with strict CSP', function() {
       cy.visit('https://buildkite.com/')
-      cy.percySnapshot('Buildkite HTTPS + CSP', { widths: [768, 992, 1200] })
+      cy.percySnapshot('Buildkite HTTPS + CSP', { widths: [768, 992, 1200], enableJavaScript: true })
     })
   })
 


### PR DESCRIPTION
Turns out that the issue that we were having with this snapshot in Cypress was simply about enabling JavaScript. Discovered this in the course of some other work.

With this change:
https://percy.io/examples/scratch/builds/1328166/view/86817939/1200?mode=diff&browser=chrome&snapshot=86817939

Before this change:
https://percy.io/examples/scratch/builds/1328156/view/86817074/1200?mode=diff&browser=chrome&snapshot=86817074