### PR TITLE
Cache the Cypress binary (fixes broken CI master build)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,14 +5,15 @@ default_steps: &default_steps
     - checkout
     - restore_cache:
         keys:
-        - v1-dependencies-{{ checksum "package.json" }}
+        - v3-dependencies-{{ checksum "package.json" }}
         # fallback to using the latest cache if no exact match is found
-        - v1-dependencies-
+        - v3-dependencies-
     - run: npm install
     - save_cache:
         paths:
           - node_modules
-        key: v1-dependencies-{{ checksum "package.json" }}
+          - ~/.cache
+        key: v3-dependencies-{{ checksum "package.json" }}
     - run: npm test
 
 jobs:


### PR DESCRIPTION
By caching `node_modules` but not the stuff that is in `~/.cache`, we end up without a Cypress binary, so re-running builds with the cache fails (e.g: https://circleci.com/gh/percy/percy-cypress/53).

(Btw, reading the Cypress docs on this, they recommend that folks don't cache `node_modules` at all, and also using `npm ci` instead of `npm install`. I haven't made those changes, but let me know if you'd like me to. Docs are here: https://docs.cypress.io/guides/guides/continuous-integration.html#Caching)

@djones for review