### PR TITLE
Use npm ci on CircleCI, and cache ~/.npm instead of node_modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,15 +5,15 @@ default_steps: &default_steps
     - checkout
     - restore_cache:
         keys:
-        - v3-dependencies-{{ checksum "package.json" }}
+        - v4-dependencies-{{ checksum "package.json" }}
         # fallback to using the latest cache if no exact match is found
-        - v3-dependencies-
-    - run: npm install
+        - v4-dependencies-
+    - run: npm ci
     - save_cache:
         paths:
-          - node_modules
+          - ~/.npm
           - ~/.cache
-        key: v3-dependencies-{{ checksum "package.json" }}
+        key: v4-dependencies-{{ checksum "package.json" }}
     - run: npm test
 
 jobs:


### PR DESCRIPTION
Verified that re-rerunning works (i.e. no caching problems): https://circleci.com/gh/percy/percy-cypress/tree/update-ci