### PR TITLE
Add 'clean' script to blow away compiled JS files, and run it before building

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:debug": "LOG_LEVEL=debug npm run test",
     "clean": "rm -rf dist/",
     "build": "npm run clean && tsc",
+    "prepublish": "npm run build",
     "lint": "tslint -p . -t stylish --fix",
     "cypress:open": "cypress open"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "pretest": "npm run build",
     "test": "percy exec -- node run-tests.js",
     "test:debug": "LOG_LEVEL=debug npm run test",
-    "build": "tsc",
+    "clean": "rm -rf dist/",
+    "build": "npm run clean && tsc",
     "lint": "tslint -p . -t stylish --fix",
     "cypress:open": "cypress open"
   },


### PR DESCRIPTION
This should make our release process more robust, as well (makes it harder to release old files, which we discovered has happened at least once).