### PR TITLE
Find and use full path to percy-healthcheck script

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,6 @@
 import {clientInfo, environmentInfo} from './environment'
 import PercyAgent from '@percy/agent'
+import * as path from 'path'
 
 declare const Cypress: any
 declare const cy: any
@@ -10,13 +11,12 @@ Cypress.Commands.add('percySnapshot', (name: string, options: any = {}) => {
   // Use cy.exec(...) to check if percy agent is running. Ideally this would be
   // done using something like cy.request(...), but that's not currently possible,
   // for details, see: https://github.com/cypress-io/cypress/issues/3161
-  // We rely on node finding the percy-healtcheck binary and running it correctly,
-  // which is more cross-platform friendly than running the script directly ourselves.
-  const healthcheck = `node percy-healthcheck ${percyAgentClient.port}`
+  const healthcheck = `node ${_healthcheckPath()} ${percyAgentClient.port}`
   cy.exec(healthcheck, {failOnNonZeroExit: false}).then((result: any) => {
     if (result.code != 0) {
       // Percy server not available, or we failed to find the healthcheck.
       cy.log('[percy] Percy agent is not running. Skipping snapshots')
+      cy.log(`[percy] Healthcheck output: ${result.stdout}\n${result.stderr}`)
       return
     }
 
@@ -42,3 +42,24 @@ Cypress.Commands.add('percySnapshot', (name: string, options: any = {}) => {
     })
   })
 })
+
+
+// An attempt to resiliently find the path to the 'percy-healthcheck' script, and to do so
+// in a cross-platform manner.
+function _healthcheckPath() {
+  try {
+    // Try to resolve with respect to the install local module.
+    return require.resolve('@percy/cypress/dist/percy-healthcheck')
+  } catch {
+    try {
+      // Try to resolve relative to the current file.
+      return require.resolve('./percy-healthcheck')
+    } catch {
+      // Oh well. Assume it's in the local node_modules.
+      // It would be nice to use __dirname here, but this code is entirely executed inside of
+      // Cypress' unusual context, making __dirname always '/dist' for this file, which is
+      // unhelpful when trying to find a working filesystem path to percy-healthcheck.
+      return path.join('.', './node_modules/@percy/cypress/dist/percy-healthcheck')
+    }
+  }
+}

--- a/lib/percy-healthcheck
+++ b/lib/percy-healthcheck
@@ -13,7 +13,10 @@ const healtcheck = options => {
     const request = http.request(options, res => {
       resolve(res.statusCode === 200)
     })
-    request.on('error', err => reject(err))
+    request.on('error', (err) => {
+      console.log(`Healthcheck failed: ${err}`)
+      reject(err)
+    })
     request.end()
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -52,7 +52,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -68,7 +68,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -476,7 +476,7 @@
     },
     "async": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "async-limiter": {
@@ -533,7 +533,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -755,7 +755,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -975,7 +975,7 @@
         },
         "ansi-escapes": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
           "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
           "dev": true
         },
@@ -1036,7 +1036,7 @@
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
         },
         "fd-slicer": {
@@ -1103,7 +1103,7 @@
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
@@ -1149,7 +1149,7 @@
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
@@ -1197,7 +1197,7 @@
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
@@ -1240,7 +1240,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
         },
         "request": {
@@ -1291,7 +1291,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -1921,7 +1921,7 @@
       "dependencies": {
         "colors": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
           "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
           "dev": true
         }
@@ -2414,7 +2414,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -2436,7 +2436,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -2452,7 +2452,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -2571,7 +2571,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
@@ -3229,7 +3229,7 @@
       "dependencies": {
         "qs": {
           "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+          "resolved": "http://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
           "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
           "dev": true
         }
@@ -3346,7 +3346,7 @@
       "dependencies": {
         "colors": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
           "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
         }
       }

--- a/package.json
+++ b/package.json
@@ -4,15 +4,12 @@
   "description": "Cypress client library for visual regression testing with Percy (https://percy.io).",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "bin": {
-    "percy-healthcheck": "percy-healthcheck"
-  },
   "scripts": {
     "pretest": "npm run build",
     "test": "percy exec -- node run-tests.js",
     "test:debug": "LOG_LEVEL=debug npm run test",
     "clean": "rm -rf dist/",
-    "build": "npm run clean && tsc",
+    "build": "npm run clean && tsc && cp lib/percy-healthcheck dist/percy-healthcheck",
     "prepublish": "npm run build",
     "lint": "tslint -p . -t stylish --fix",
     "cypress:open": "cypress open"

--- a/run-tests.js
+++ b/run-tests.js
@@ -4,13 +4,14 @@ const port = process.env.PORT_NUMBER || 8000;
 const spawn = require('child_process').spawn;
 const platform = require('os').platform();
 
-// Copy our healthcheck binary to the 'node_modules/.bin' directory where it will be
+// Copy our healthcheck script to node_modules, where it will be
 // when this package is installed as a dependency.
-const src = 'percy-healthcheck'
+const src = 'lib/percy-healthcheck'
 const copyDst = /^win/.test(platform)
-      ? `${process.cwd()}\\node_modules\\.bin\\percy-healthcheck`
-      : `${__dirname}/node_modules/.bin/percy-healthcheck`;
+      ? `${process.cwd()}\\node_modules\\@percy\\cypress\\dist\\percy-healthcheck`
+      : `${__dirname}/node_modules/@percy/cypress/dist/percy-healthcheck`;
 console.log(`[run-tests] Copying ${src} to ${copyDst}`);
+fs.mkdirSync('./node_modules/@percy/cypress/dist', { recursive: true });
 fs.copyFileSync(src, copyDst);
 
 // We need to change the command path based on the platform they're using

--- a/run-tests.js
+++ b/run-tests.js
@@ -4,6 +4,13 @@ const port = process.env.PORT_NUMBER || 8000;
 const spawn = require('child_process').spawn;
 const platform = require('os').platform();
 
+// Helper to make sure directories we need exist.
+function ensureDirExists(dir) {
+  if (! fs.existsSync(dir)) {
+    fs.mkdirSync(dir)
+  }
+}
+
 // Copy our healthcheck script to node_modules, where it will be
 // when this package is installed as a dependency.
 const src = 'lib/percy-healthcheck'
@@ -11,7 +18,10 @@ const copyDst = /^win/.test(platform)
       ? `${process.cwd()}\\node_modules\\@percy\\cypress\\dist\\percy-healthcheck`
       : `${__dirname}/node_modules/@percy/cypress/dist/percy-healthcheck`;
 console.log(`[run-tests] Copying ${src} to ${copyDst}`);
-fs.mkdirSync('./node_modules/@percy/cypress/dist', { recursive: true });
+// The 'recursive' fs.mkdirSync() option is only available in Node >10.12.0;
+// create all directories ourselves to accommodate Node 8.
+ensureDirExists('./node_modules/@percy/cypress')
+ensureDirExists('./node_modules/@percy/cypress/dist')
 fs.copyFileSync(src, copyDst);
 
 // We need to change the command path based on the platform they're using


### PR DESCRIPTION
The main change here is getting away from trying to rely on `node` to find the path to a `bin` we install, and instead try to compute the full path to the `percy-healthcheck` script ourselves, in a way similar to how we do that for `percy-agent.js`.

This change also adds some additional logging that should help in the case when the healthcheck fails. 

I did not succeed in doing a magic `npm link` before calling the tests, so that in the package tests we can rely on `@percy/cypress` being installed, so I'm still falling back on the somewhat ugly option of manually copying stuff into `node_modules` before the tests run. Since this is just for development (for the tests in this package), I think that's ok.

@Robdel12 @djones for review 