### PR TITLE
fix: catch webpack removing require.resolve

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -43,17 +43,25 @@ Cypress.Commands.add('percySnapshot', (name: string, options: any = {}) => {
   })
 })
 
+const checkResolved = (x: string) => {
+  // we are resolving a path to the module
+  // and Webpack changes it to a number, then something is wrong
+  if (typeof x !== 'string') {
+    throw new Error('Should be a string')
+  }
+  return x
+}
 
 // An attempt to resiliently find the path to the 'percy-healthcheck' script, and to do so
 // in a cross-platform manner.
 function _healthcheckPath() {
   try {
     // Try to resolve with respect to the install local module.
-    return require.resolve('@percy/cypress/dist/percy-healthcheck')
+    return checkResolved(require.resolve('@percy/cypress/dist/percy-healthcheck'))
   } catch {
     try {
       // Try to resolve relative to the current file.
-      return require.resolve('./percy-healthcheck')
+      return checkResolved(require.resolve('./percy-healthcheck'))
     } catch {
       // Oh well. Assume it's in the local node_modules.
       // It would be nice to use __dirname here, but this code is entirely executed inside of

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cypress",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Cypress client library for visual regression testing with Percy (https://percy.io).",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -24,6 +24,9 @@
   "engines": {
     "node": ">=8.0.0"
   },
+  "files": [
+    "dist"
+  ],
   "author": "Perceptual Inc.",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Whenever webpack has `{node: {fs: 'empty'}}` option it replaces `require.resolve` with just `/* require.resolve */(moduleId: number)` which leads to the wrong health check attempt. This little sanity check makes the healthcheck fall all the way through to the local relative path.

- closes #58 