### PR TITLE
Pass `domTransformation` option to PercyAgent constructor

### DIFF
--- a/cypress/integration/sdk_spec.js
+++ b/cypress/integration/sdk_spec.js
@@ -38,6 +38,17 @@ describe('@percy/cypress', function() {
       cy.get('.todo-count').should('contain', '0 items left')
       cy.percySnapshot('Multiple snapshots #2 -- 1 checked-off todo')
     })
+
+    it('snapshots part of a page', function() {
+      cy.percySnapshot('With a passed domTransformation function', {
+        domTransformation: (documentClone) => {
+          let footerElement = documentClone.querySelector('footer.info');
+          documentClone.querySelector('body').innerHTML = footerElement.outerHTML;
+
+          return documentClone;
+        }
+      })
+    })
   })
 
   describe('with live sites', function() {

--- a/cypress/integration/sdk_spec.js
+++ b/cypress/integration/sdk_spec.js
@@ -41,12 +41,7 @@ describe('@percy/cypress', function() {
 
     it('snapshots part of a page', function() {
       cy.percySnapshot('With a passed domTransformation function', {
-        domTransformation: (documentClone) => {
-          let footerElement = documentClone.querySelector('footer.info');
-          documentClone.querySelector('body').innerHTML = footerElement.outerHTML;
-
-          return documentClone;
-        }
+        domTransformation: documentClone => scope(documentClone, 'footer.info')
       })
     })
   })
@@ -73,3 +68,11 @@ describe('@percy/cypress', function() {
   })
 
 })
+
+
+function scope(documentClone, selector) {
+  let element = documentClone.querySelector(selector);
+  documentClone.querySelector('body').innerHTML = element.outerHTML;
+
+  return documentClone;
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,7 +6,10 @@ declare const Cypress: any
 declare const cy: any
 
 Cypress.Commands.add('percySnapshot', (name: string, options: any = {}) => {
-  const percyAgentClient = new PercyAgent({ handleAgentCommunication: false })
+  const percyAgentClient = new PercyAgent({
+    handleAgentCommunication: false,
+    domTransformation: options.domTransformation
+  })
 
   // Use cy.exec(...) to check if percy agent is running. Ideally this would be
   // done using something like cy.request(...), but that's not currently possible,


### PR DESCRIPTION
Percy agent accepts a `domTransformation` option in its constructor, but currently our cypress sdk is not passing it into the right place. It is currently passing it into the `percySnapshot` method, where it should be passed to the `percyAgent` `constructor` method. This PR passes it to the constructor method.