### PR TITLE
Point to healthcheck inside of the `dist` folder always

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,18 +5,22 @@ import * as path from 'path'
 declare const Cypress: any
 declare const cy: any
 
+// it will always live in the node_modules path
+const HEALTHCHECK_PATH = 'node_modules/@percy/cypress/dist/percy-healthcheck';
+
 Cypress.Commands.add('percySnapshot', (name: string, options: any = {}) => {
   const percyAgentClient = new PercyAgent({ handleAgentCommunication: false })
 
   // Use cy.exec(...) to check if percy agent is running. Ideally this would be
   // done using something like cy.request(...), but that's not currently possible,
   // for details, see: https://github.com/cypress-io/cypress/issues/3161
-  const healthcheck = `node ${_healthcheckPath()} ${percyAgentClient.port}`
-  cy.exec(healthcheck, {failOnNonZeroExit: false}).then((result: any) => {
-    if (result.code != 0) {
+  const healthcheckCmd = `node ${HEALTHCHECK_PATH} ${percyAgentClient.port}`
+  cy.exec(healthcheckCmd, { failOnNonZeroExit: false }).then((result: any) => {
+    if (result.code !== 0) {
       // Percy server not available, or we failed to find the healthcheck.
       cy.log('[percy] Percy agent is not running. Skipping snapshots')
       cy.log(`[percy] Healthcheck output: ${result.stdout}\n${result.stderr}`)
+
       return
     }
 
@@ -42,24 +46,3 @@ Cypress.Commands.add('percySnapshot', (name: string, options: any = {}) => {
     })
   })
 })
-
-
-// An attempt to resiliently find the path to the 'percy-healthcheck' script, and to do so
-// in a cross-platform manner.
-function _healthcheckPath() {
-  try {
-    // Try to resolve with respect to the install local module.
-    return require.resolve('@percy/cypress/dist/percy-healthcheck')
-  } catch {
-    try {
-      // Try to resolve relative to the current file.
-      return require.resolve('./percy-healthcheck')
-    } catch {
-      // Oh well. Assume it's in the local node_modules.
-      // It would be nice to use __dirname here, but this code is entirely executed inside of
-      // Cypress' unusual context, making __dirname always '/dist' for this file, which is
-      // unhelpful when trying to find a working filesystem path to percy-healthcheck.
-      return path.join('.', './node_modules/@percy/cypress/dist/percy-healthcheck')
-    }
-  }
-}


### PR DESCRIPTION
## What is this?

This removes the healthcheck dance that uses `require` and `path`, which aren't available in the browser. It wasn't quite transpiling properly (#69), so if this doesn't actually work well, we should look at making changes to how this SDK is distributed.

It looks like `cy.exec` takes care of any cross platform issues. All tests pass -- I'm curious what this might be missing? Seems like `cy.exec` also resolves the path properly. **Before** merge I'd like to cut a beta and have some folks try it out that had the healthcheck issues in #61. Just to be 100% sure we're not regressing (since we haven't been able to replicate)

### Open question

Is this healthcheck really needed? I'm curious what it's meant to do? Is it to provide helpful logging for when a snapshot fails? _How_ does it fail if the server isn't available? `cy.request()` doesn't fail the cypress test build and we can `.catch` any errors from it and provide nice logs from there I believe. 

It might be that this pain can just go away with that. Curious to hear thoughts on this. 