### PR TITLE
chore: Remove unneeded `path` import

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,5 @@
 import {clientInfo, environmentInfo} from './environment'
 import PercyAgent from '@percy/agent'
-import * as path from 'path'
 
 declare const Cypress: any
 declare const cy: any


### PR DESCRIPTION
## What is this? 

When working on #73, I forgot to remove this import which is no longer used.