### PR TITLE
chore: fallback enableJavaScript to true

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -35,7 +35,7 @@ Cypress.Commands.add('percySnapshot', (name: string, options: any = {}) => {
         body: {
           name,
           url: doc.URL,
-          enableJavaScript: options.enableJavaScript,
+          enableJavaScript: (typeof options.enableJavaScript !== 'undefined') ? options.enableJavaScript : true,
           widths: options.widths,
           clientInfo,
           environmentInfo,


### PR DESCRIPTION
Percy snapshots fallback to a browser where JavaScript is disabled in the first place. As this is not documented somewhere, it would probably have to have a fallback to value true.