### PR TITLE
fix: Open `@percy/agent` version range (tilde over caret)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typescript": "^3.0.3"
   },
   "dependencies": {
-    "@percy/agent": "^0.4.0"
+    "@percy/agent": "~0"
   },
   "release": {
     "plugins": [


### PR DESCRIPTION
## What is this?

This is needed because the caret (`^`) "allows changes that do not modify the left-most non-zero digit in the [major, minor, patch] tuple": https://github.com/npm/node-semver#caret-ranges-123-025-004

This means `^0.2.2` will only ever update if we release more `0.2.x` releases, but nothing higher.

We can use the tilde to open the range up more _until_ we hit 1.x for `@percy/agent`. More information about the semver tilde: https://github.com/npm/node-semver#tilde-ranges-123-12-1