### PR TITLE
fix: Pass minHeight option along to agent

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -26,6 +26,7 @@ Cypress.Commands.add('percySnapshot', (name: string, options: any = {}) => {
             url: doc.URL,
             enableJavaScript: options.enableJavaScript,
             widths: options.widths,
+            minHeight: options.minHeight,
             clientInfo: clientInfo(),
             environmentInfo: environmentInfo(),
             domSnapshot


### PR DESCRIPTION
## Purpose

In our docs, we show that `minHeight` is [an option](https://docs.percy.io/docs/cypress#section-configuration) when using the Cypress SDK. This option is never passed along to agent.

## Approach

Send agent the `minHeight` option.