### PR TITLE
fix: add `percyCSS` option to types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,9 @@
 
 interface SnapshotOptions {
-  enableJavaScript?: boolean,
   widths?: number[],
+  percyCSS?: string,
   minHeight?: number,
+  enableJavaScript?: boolean,
 }
 
 declare namespace Cypress {


### PR DESCRIPTION
## What is this?

I forgot to update the types file when we added `percyCSS`. This closes #155 