### PR TITLE
feat: Add request headers option for asset-discovery

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@
 interface SnapshotOptions {
   widths?: number[],
   percyCSS?: string,
+  requestHeaders?: { (key: string): string },
   minHeight?: number,
   enableJavaScript?: boolean,
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -29,6 +29,7 @@ Cypress.Commands.add('percySnapshot', (name: string, options: any = {}) => {
             minHeight: options.minHeight,
             clientInfo: clientInfo(),
             percyCSS: options.percyCSS,
+            requestHeaders: options.requestHeaders,
             environmentInfo: environmentInfo(),
             domSnapshot
           }


### PR DESCRIPTION
## Purpose

Adds the `requestHeaders` option for agent so we can pass request headers for asset-discovery.