### PR TITLE
fix: Update peerDependencies for Cypress v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "axios": "^0.19.0"
   },
   "peerDependencies": {
-    "cypress": "^3"
+    "cypress": "^3 || ^4"
   },
   "release": {
     "plugins": [


### PR DESCRIPTION
This will close #193

(We're fully compatible, this will suppress any warnings/errors on install) 