### PR TITLE
fix: Add cypress 5 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "axios": "^0.20.0"
   },
   "peerDependencies": {
-    "cypress": "^3 || ^4"
+    "cypress": "^3 || ^4 || ^5"
   },
   "release": {
     "plugins": [


### PR DESCRIPTION
We have been happily using with Cypress 5 for several months, this removes the warning when running yarn that it is incompatible.