### PR TITLE
fix: Update Cypress `peerDependency` for Cypress 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "axios": "^0.21.0"
   },
   "peerDependencies": {
-    "cypress": "^3 || ^4 || ^5"
+    "cypress": "^3 || ^4 || ^5 || ^6"
   },
   "release": {
     "plugins": [


### PR DESCRIPTION
Will close #287 