### PR TITLE
🔧 Prepare for v3

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -28,4 +28,3 @@ version-resolver:
       - enhancement
   default: patch
 template: '$CHANGES'
-prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,6 @@ jobs:
           key: v1/${{ runner.os }}/node-12/${{ hashFiles('**/yarn.lock') }}
           restore-keys: v1/${{ runner.os }}/node-12/
       - run: yarn
-      - run: npm publish --tag next
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -73,6 +73,23 @@ $ percy exec -- cypress run
 
 ## Upgrading
 
+### Automatically with `@percy/migrate`
+
+We built a tool to help automate migrating to the new CLI toolchain! Migrating
+can be done by running the following commands and following the prompts:
+
+``` shell
+$ npx @percy/migrate
+? Are you currently using @percy/cypress? Yes
+? Install @percy/cli (required to run percy)? Yes
+? Migrate Percy config file? Yes
+? Upgrade SDK to @percy/cypress@3.0.0? Yes
+```
+
+This will automatically run the changes described below for you.
+
+### Manually
+
 #### Installing `@percy/cli`
 
 If you're coming from a pre-3.0 version of this package, make sure to install `@percy/cli` after

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/cypress",
   "description": "Cypress client library for visual testing with Percy",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-cypress",


### PR DESCRIPTION
## What is this?

Prepares for v3 release by removing prerelease references and adding `@percy/migrate` instructions to the readme.