### PR TITLE
✨  Disable Percy when Cypress is in interactive mode

### DIFF
--- a/cypress/integration/index.test.js
+++ b/cypress/integration/index.test.js
@@ -65,4 +65,31 @@ describe('percySnapshot', () => {
       '[percy] Error: 500 Internal Server Error'
     ]);
   });
+
+  describe('in interactive mode', () => {
+    let ogInteractive;
+
+    beforeEach(() => {
+      ogInteractive = Cypress.config('isInteractive');
+    });
+
+    afterEach(() => {
+      Cypress.config('isInteractive', ogInteractive);
+    });
+
+    it('disables snapshots', () => {
+      Cypress.config('isInteractive', true);
+      cy.percySnapshot('Snapshot name');
+
+      cy.get('@log').should((spy) => {
+        expect(spy).to.be.calledWith(
+          match({
+            name: 'percySnapshot',
+            displayName: 'percy',
+            message: 'Disabled in interactive mode'
+          })
+        );
+      });
+    });
+  });
 });

--- a/index.js
+++ b/index.js
@@ -32,6 +32,14 @@ Cypress.Commands.add('percySnapshot', (name, options) => {
   name = name || cy.state('runnable').fullTitle();
 
   cy.then(async () => {
+    if (Cypress.config('isInteractive') &&
+        !Cypress.config('enablePercyInteractiveMode')) {
+      return cylog('Disabled in interactive mode', {
+        details: 'use "cypress run" instead of "cypress open"',
+        name
+      });
+    }
+
     // Check if Percy is enabled
     if (!await utils.isPercyEnabled()) {
       return cylog('Not running', { name });

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,7 +950,7 @@
   dependencies:
     dotenv "^8.2.0"
 
-"@percy/logger@^1.0.0-beta.44", "@percy/logger@^1.0.0-beta.47":
+"@percy/logger@^1.0.0-beta.47":
   version "1.0.0-beta.47"
   resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.0.0-beta.47.tgz#72d91b693b43c59f1cccffdfafec70adc9ffc1a8"
   integrity sha512-6mDHvIQ8wJCN7dd9bnnKtT/VrE+HBTB+U9C7a7vSakC35DnY4QrxH1sbK4hAO8wc2aw6YR3vepX2w/ZYpeuqnA==


### PR DESCRIPTION
## Purpose

Percy is designed (at this time) to run in CI, with one complete test run to each build. Running Percy when doing TDD style tests (or anything watching changes like `cypress open`) will result in duplicate snapshot errors/unexpected results. 

On top of that, a recent bug in the Cypress networking layer (likely https://github.com/cypress-io/cypress/issues/15101) causes any tests that call `cy.percySnapshot` to hang/break (since we make a network request, which eventually causes that callstack error in Cypress). 

## Approach

Since Percy's workflow is already misaligned with using `cypress open`, we're going to disable Percy from running / making network calls in Cypress Interactive mode. This could result in empty builds, which will eventually be handled upstream in `@percy/core` when we implement a lazy snapshot queue. 

Will close #315 