### PR TITLE
🐛  Increase timeout to 1.5x the asset discovery timeout (30s)

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,9 @@ const utils = require('@percy/sdk-utils');
 const sdkPkg = require('./package.json');
 const CLIENT_INFO = `${sdkPkg.name}/${sdkPkg.version}`;
 const ENV_INFO = `cypress/${Cypress.version}`;
+// asset discovery should timeout before this
+// 1.5 times the 30 second nav timeout
+const CY_TIMEOUT = 30 * 1000 * 1.5;
 
 // Maybe set the CLI API address from the environment
 utils.percy.address = Cypress.env('PERCY_SERVER_ADDRESS');
@@ -31,7 +34,7 @@ Cypress.Commands.add('percySnapshot', (name, options) => {
   // Default name to test title
   name = name || cy.state('runnable').fullTitle();
 
-  cy.then(async () => {
+  return cy.then({ timeout: CY_TIMEOUT }, async () => {
     if (Cypress.config('isInteractive') &&
         !Cypress.config('enablePercyInteractiveMode')) {
       return cylog('Disabled in interactive mode', {
@@ -52,7 +55,7 @@ Cypress.Commands.add('percySnapshot', (name, options) => {
     }
 
     // Serialize and capture the DOM
-    return cy.document({ log: false }).then(dom => {
+    return cy.document({ log: false }).then({ timeout: CY_TIMEOUT }, dom => {
       let domSnapshot = window.PercyDOM.serialize({ ...options, dom });
 
       // Post the DOM snapshot to Percy


### PR DESCRIPTION
## What is this?

Assets that take a long time to respond in asset discovery can cause the `cy.then` promise to timeout. We _must_ wait for all assets to be discovered/resolved/captured before moving onto the next test, or we risk capturing the wrong asset for that given snapshot. For example, if the server shuts down after each test, we would fail to capture those assets if we didn't await on asset discovery to finish (resulting in broken snapshots).

With that said, we can safely increase this timeout beyond asset discoveries timeout since asset discovery will timeout first.