### PR TITLE
✅ Use Percy CLI testing mode for tests

### DIFF
--- a/cypress/e2e/index.cy.js
+++ b/cypress/e2e/index.cy.js
@@ -1,31 +1,22 @@
-import helpers from '@percy/sdk-utils/test/client';
+import helpers from '@percy/sdk-utils/test/helpers';
 
 const { match } = Cypress.sinon;
 
 describe('percySnapshot', () => {
   beforeEach(() => {
-    cy.then(helpers.setup);
-    cy.visit('http://localhost:8000');
+    cy.then(helpers.setupTest);
+    cy.visit(helpers.testSnapshotURL);
     cy.wrap(cy.spy(Cypress, 'log').log(false)).as('log');
   });
 
-  afterEach(() => {
-    cy.then(helpers.teardown);
-  });
-
   it('disables snapshots when the healthcheck fails', () => {
-    cy.then(() => helpers.testFailure('/percy/healthcheck'));
+    cy.then(() => helpers.test('error', '/percy/healthcheck'));
 
     cy.percySnapshot();
     cy.percySnapshot('Snapshot 2');
 
-    cy.then(helpers.getRequests).should('deep.equal', [
-      ['/percy/healthcheck']
-    ]);
-
-    cy.wrap(helpers.logger.stderr).should('deep.equal', []);
-    cy.wrap(helpers.logger.stdout).should('deep.equal', [
-      '[percy] Percy is not running, disabling snapshots'
+    cy.then(() => helpers.get('logs')).should('include.members', [
+      'Percy is not running, disabling snapshots'
     ]);
   });
 
@@ -33,36 +24,21 @@ describe('percySnapshot', () => {
     cy.percySnapshot();
     cy.percySnapshot('Snapshot 2');
 
-    cy.then(helpers.getRequests).should(requests => {
-      // test stub so we can utilize sinon matchers
-      let test = cy.stub(); test(requests);
-
-      expect(test).to.be.calledWith(match([
-        match(['/percy/healthcheck']),
-        match(['/percy/dom.js']),
-        match(['/percy/snapshot', match({
-          name: 'percySnapshot posts snapshots to the local percy server',
-          url: 'http://localhost:8000/',
-          domSnapshot: match(/<html><head>(.*?)<\/head><body>Snapshot Me<\/body><\/html>/),
-          clientInfo: match(/@percy\/cypress\/.+/),
-          environmentInfo: match(/cypress\/.+/)
-        })]),
-        match(['/percy/snapshot', match({
-          name: 'Snapshot 2'
-        })])
-      ]));
-    });
+    cy.then(() => helpers.get('logs'))
+      .should('include', `Snapshot found: ${cy.state('runnable').fullTitle()}`)
+      .should('include', `- url: ${helpers.testSnapshotURL}`)
+      .should('include.match', /clientInfo: @percy\/cypress\/.+/)
+      .should('include.match', /environmentInfo: cypress\/.+/)
+      .should('include', 'Snapshot found: Snapshot 2');
   });
 
   it('handles snapshot failures', () => {
-    cy.then(() => helpers.testFailure('/percy/snapshot'));
+    cy.then(() => helpers.test('error', '/percy/snapshot'));
 
     cy.percySnapshot();
 
-    cy.wrap(helpers.logger.stdout).should('deep.equal', []);
-    cy.wrap(helpers.logger.stderr).should('deep.equal', [
-      '[percy] Could not take DOM snapshot "percySnapshot handles snapshot failures"',
-      '[percy] Error: 500 Internal Server Error'
+    cy.then(() => helpers.get('logs')).should('include.members', [
+      'Could not take DOM snapshot "percySnapshot handles snapshot failures"'
     ]);
   });
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "lint": "eslint --ignore-path .gitignore .",
-    "test": "node ./node_modules/@percy/sdk-utils/test/server exec -- cypress run",
+    "test": "percy exec --testing -- cypress run",
     "coverage": "nyc report --check-coverage",
     "test:coverage": "yarn test && yarn coverage",
     "test:types": "tsd"
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.10.0",
-    "@percy/core": "^1.3.1",
+    "@percy/cli": "^1.9.1",
     "babel-loader": "^8.2.5",
     "babel-plugin-istanbul": "^6.0.0",
     "cypress": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -383,33 +383,96 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@percy/client@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.9.0.tgz#66cadb1e052034d05b3524c2928fda652820e0be"
-  integrity sha512-Rc0S0s7bXbomxILxOQFbE7u8FUUcMa1NQGGB8ioFjn8uh+5Qs19ERmqe6/J60MNUcPuXZCcoqDDbqEyKV0OGZQ==
+"@percy/cli-build@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.9.1.tgz#aa2408929bf116a7742c62ebadb3b1e30844fa07"
+  integrity sha512-BeviHvXOnX74Cntw99hRe0HY2eiqFm9BASkfjSB5AoEdtxLKm0xfYM0WcOIec5XtlztRrQKHA49VVOh2pLWK1Q==
   dependencies:
-    "@percy/env" "1.9.0"
-    "@percy/logger" "1.9.0"
+    "@percy/cli-command" "1.9.1"
 
-"@percy/config@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.9.0.tgz#6811c9ef3e67bac9c344a87ea3efe5101d1cc17c"
-  integrity sha512-g0HnUhk6nfTXp9rndBBWw3beXT8Vhfh2iQv8tJjgUY9I0catj2qkAhhSiWHY8qyBLe6ImXB7GYTGeIIyU7s1gw==
+"@percy/cli-command@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.9.1.tgz#bf492875573fc4fc63a9ebf62b33749f298442e6"
+  integrity sha512-4vzOUyorU+0KbqpqXTlSfqRBi+XCPDuPRekNwd0HTsgIQB3KQ8Us5cEhk5x2q8/y0jPHqCb5BK/GJBpS8lwO3Q==
   dependencies:
-    "@percy/logger" "1.9.0"
+    "@percy/config" "1.9.1"
+    "@percy/core" "1.9.1"
+    "@percy/logger" "1.9.1"
+
+"@percy/cli-config@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.9.1.tgz#e095bf66bec66db0bced9ee926c30a211936321a"
+  integrity sha512-R6bimILhdLswXWnIyU+1+X3h6N0xXuwOBcNT8X3GrcTrBFZJpDJ7CNCxj7f6B5Z5uuEFsvdJKN8rRYfVKLRpwg==
+  dependencies:
+    "@percy/cli-command" "1.9.1"
+
+"@percy/cli-exec@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.9.1.tgz#31ff86b372dc44ce163c0f218c8758413c84d89e"
+  integrity sha512-upWZhJYBvIbQYPhkh0np+RfMYthnhph1FXwaa/Rj4N+RiU/Qb0rFwDf6fz1Je0m1XNPhXu1R/5FnC30W+SsgAg==
+  dependencies:
+    "@percy/cli-command" "1.9.1"
+    cross-spawn "^7.0.3"
+    which "^2.0.2"
+
+"@percy/cli-snapshot@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.9.1.tgz#b494484b08bbc5927bc7b6a9353c4d59b076be0e"
+  integrity sha512-cI4oXI6vrDPEuQaU4xx6wmMozyzhUooNBRh+flu52CQcog6K9DuJnkUuu+Uf/guMX2tacp30UfAq/IMaH3AenA==
+  dependencies:
+    "@percy/cli-command" "1.9.1"
+    yaml "^2.0.0"
+
+"@percy/cli-upload@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.9.1.tgz#f1d97be77cd36574b5a57129be1d3dc1c81bb374"
+  integrity sha512-g72PepLUU0XgZiYSGcSn8nUxTbEW7NYGgh+uo/J3rnIp5OyH5olpIz/+r3+OXezAAwgyLQTSv+/pYY4ClkvQaQ==
+  dependencies:
+    "@percy/cli-command" "1.9.1"
+    fast-glob "^3.2.11"
+    image-size "^1.0.0"
+
+"@percy/cli@^1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.9.1.tgz#0df5b6af5dd848ed1c2a57db4f6e2b547583fe3c"
+  integrity sha512-B62SYu2vHGcR1lkQzP2RHHJRjuEBoWwgeccwBf3mYSzwl4fEB6n1feBRKDx7UNCazRnAzXKrL+g4X7FIesHqnA==
+  dependencies:
+    "@percy/cli-build" "1.9.1"
+    "@percy/cli-command" "1.9.1"
+    "@percy/cli-config" "1.9.1"
+    "@percy/cli-exec" "1.9.1"
+    "@percy/cli-snapshot" "1.9.1"
+    "@percy/cli-upload" "1.9.1"
+    "@percy/client" "1.9.1"
+    "@percy/logger" "1.9.1"
+
+"@percy/client@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.9.1.tgz#b6d7278436942bf241154cd79a123e23c4cdbcba"
+  integrity sha512-8A2WBoXV+zFT/+P2j8fflPOhv7dX0LNrk6bivgB6E1d6o9xcxEO94KNEIlU4hWkFC2vi+u5fpQXi+OWYQle2wQ==
+  dependencies:
+    "@percy/env" "1.9.1"
+    "@percy/logger" "1.9.1"
+
+"@percy/config@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.9.1.tgz#382d0ff8d7b94da7cbe5ad823c5553b1c9af11a7"
+  integrity sha512-LY8SBM7ngoLOItr6HOqu0dludsw6G/8dk7U3aMivzUYMZuO05maD7XlTTqfYr8HKUvxG7F6ZXQrRSG0SvwOFVg==
+  dependencies:
+    "@percy/logger" "1.9.1"
     ajv "^8.6.2"
     cosmiconfig "^7.0.0"
     yaml "^2.0.0"
 
-"@percy/core@^1.3.1":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.9.0.tgz#665e4dcc1a6516b0a9e9cf2569986c17d2297f3e"
-  integrity sha512-9BdqyetwhNUV2AGr65PZfBo5oms6eKzc0hi1yb43Dlb7EY0RRBFq01EXT5J71wEgNqsTk0B7IZ+fBvJwjcbOfw==
+"@percy/core@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.9.1.tgz#ba5a22073cfbf15c20b1964986a8f50b5ee5d024"
+  integrity sha512-LLqRoqd2AmbcV4CXQBceeaoZlQGSUN5qyfsNRYQ/7c8AmgTbccy5C1N8bpqaeiyqTpJWduXFGg1TI9awgi1UWQ==
   dependencies:
-    "@percy/client" "1.9.0"
-    "@percy/config" "1.9.0"
-    "@percy/dom" "1.9.0"
-    "@percy/logger" "1.9.0"
+    "@percy/client" "1.9.1"
+    "@percy/config" "1.9.1"
+    "@percy/dom" "1.9.1"
+    "@percy/logger" "1.9.1"
     content-disposition "^0.5.4"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
@@ -420,25 +483,25 @@
     rimraf "^3.0.2"
     ws "^8.0.0"
 
-"@percy/dom@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.9.0.tgz#4d52fb401111006ef49bd3b8cdc3fe9700ebcb55"
-  integrity sha512-Js0JCow9d4g7wqTqGgzwIMKG8apV/6BUJ7vM57K1t2y+MLiPKDiu4VC+6WIxIDs2wAUIN6j5byQKNv/G337qzA==
+"@percy/dom@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.9.1.tgz#0a034be46260d440884e6a3c5d4bda04eeff49af"
+  integrity sha512-/3q0SkimuCHANbQlnT1pDPQNb01YHtEEYNvkLv4SHFGkbOyGkZb2QEXbPryjZ0ApgLi3nm7TkKR6kNXugprhXw==
 
-"@percy/env@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.9.0.tgz#cd599c604a0e764b5c1114cfab839aed766d1dd4"
-  integrity sha512-xkg0oSX7FHXA9T9aLUhvl9YsG1arYFdt8BNTcrDW//kOt/oJX/9hsBXlVxpfhUcK21S7TPvv3UEVVkOW/ZCMlg==
+"@percy/env@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.9.1.tgz#568bd6b7048fe1fd2cf00de24a423bd807d6fe23"
+  integrity sha512-8zkZrNDBuPFUA6gSi7rYeK+TMuXTgH6bQCQYPlQJuIrSXA4CbLWaL8S3qX69hk91F9DB4glhIgR9N4RWO+R5EQ==
 
-"@percy/logger@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.9.0.tgz#945239dbaaf543e460a81fe5ba4a91ab8c6bb92e"
-  integrity sha512-lnRE8PkvAjSriztJqUkVT+qNhGMjNK+UTL4aUYA/WVAYDLeQmhCRREHHc301X8sFyPIOyQ1KA1WzCEfFuHisaA==
+"@percy/logger@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.9.1.tgz#d5a4f30ca60d56eb2b1700fb56fd8e4e55dfbbfa"
+  integrity sha512-WOtU8eX/fsgz49Hh6N8hSpy95WJV209G9yGFVaZXWIbKJ90FWrONksX/Kz8FxQ0q/7oIW36zXy0ibr2qRy095g==
 
 "@percy/sdk-utils@^1.3.1":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.8.0.tgz#8db2aefbb211747f8f622db6daf25b781464a308"
-  integrity sha512-ehyYs7L4MDmqjBAfTHA8wDGrsDHiPrJ5SwMA9g9tT06VUey1JJtjSK30VidoouZQm+Sus9r5lW/K73CQZc3lSg==
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.9.1.tgz#daa5d2cb9a2dfb306c094c3b6e1ae3891846f5e4"
+  integrity sha512-/9k1XDYj3xl9xI/cQM1uItIcC8HWpm12sYVAZRMKdddCPc3SAQN93sgVZXF3L4uGgaNiTD1+AtkzuUVSccUpPQ==
 
 "@tsd/typescript@~4.7.4":
   version "4.7.4"
@@ -2087,6 +2150,13 @@ ignore@^5.1.1, ignore@^5.1.4, ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
+image-size@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.0.2.tgz#d778b6d0ab75b2737c1556dd631652eb963bc486"
+  integrity sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==
+  dependencies:
+    queue "6.0.2"
+
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -2113,7 +2183,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3047,6 +3117,13 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+queue@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/queue/-/queue-6.0.2.tgz#b91525283e2315c7553d2efa18d83e76432fed65"
+  integrity sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==
+  dependencies:
+    inherits "~2.0.3"
+
 quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
@@ -3748,7 +3825,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@^2.0.1:
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==


### PR DESCRIPTION
## What is this?

This PR updates tests to utilize CLI's new testing mode and updated `@percy/sdk-utils` test helpers.