### PR TITLE
Rethrow the error to cypress

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ Cypress.Commands.add('percySnapshot', (name, options) => {
         // Handle errors
         log.error(`Could not take DOM snapshot "${name}"`);
         log.error(error);
+        throw error;
       });
     });
   });


### PR DESCRIPTION
When percy fails to take the snapshot we should rethrow the error to cypress to fail the test case.

Resolves #568