### PR TITLE
Changed OR operator to old syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ Cypress.Commands.add('percySnapshot', (name, options = {}) => {
     name = undefined;
   }
   // Default name to test title
-  name ||= cy.state('runnable').fullTitle();
+  name = name || cy.state('runnable').fullTitle();
 
   const meta = {
     snapshot: {


### PR DESCRIPTION
The new syntax for OR operator `name ||= cy.state('runnable').fullTitle();` is not supported and gives error. 

Reverted the syntax for this to initial one i.e `name = name || cy.state('runnable').fullTitle();`