### PR TITLE
fix: add timeout to cookie retrieval in percySnapshot command

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ Cypress.Commands.add('percySnapshot', (name, options = {}) => {
       }, 'taking dom snapshot');
 
       // Capture cookies
-      return cy.getCookies({ log: false }).then(async (cookies) => {
+      return cy.getCookies({ log: false }).then({ timeout: CY_TIMEOUT }, async (cookies) => {
         if (cookies && cookies.length > 0) {
           domSnapshot.cookies = cookies;
         }


### PR DESCRIPTION
The default timeout of 4000ms is failing for one customer. 
We are using our default cypress timeout of 45000ms