### PR TITLE
chore: set publishConfig.tag to beta for 3.1.9-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "main": "index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
The merged release PR (#1099) bumped the version to 3.1.9-beta.0 but left `publishConfig.tag` at `latest`. Without this change, `npm publish` would publish the beta under the `latest` dist-tag.