### PR TITLE
fix: run readiness gate in the AUT realm, not the Cypress runner frame (PER-7348)

### DIFF
--- a/cypress/e2e/index.cy.js
+++ b/cypress/e2e/index.cy.js
@@ -408,21 +408,21 @@ describe('percySnapshot', () => {
   });
 
   describe('readiness gate', () => {
-    // The SDK's percySnapshot command reads `window.PercyDOM` from the spec
-    // runner window (where the SDK module was eval'd). cy.window() returns
-    // the AUT window -- stubbing there is invisible to the SDK. Set the
-    // stub on the spec runner window via cy.then so it executes inside
-    // Cypress's command chain but stays in the same global as the SDK.
+    // The SDK injects + runs PercyDOM in the app-under-test realm
+    // (doc.defaultView), so stub PercyDOM on the AUT window via cy.window().
+    // (It previously read window.PercyDOM from the spec runner frame, which
+    // silently ran the readiness gate against the wrong document; stubbing on
+    // the AUT window matches the fix and guards that regression.)
     const installPercyDOMStub = (stub) => {
-      cy.then(() => {
-        window.PercyDOM = stub;
+      cy.window({ log: false }).then((win) => {
+        win.PercyDOM = stub;
       });
     };
 
     afterEach(() => {
       const utils = require('@percy/sdk-utils');
       if (utils.percy) utils.percy.config = undefined;
-      cy.then(() => { delete window.PercyDOM; });
+      cy.window({ log: false }).then((win) => { delete win.PercyDOM; });
     });
 
     it('calls waitForReady before serialize when the CLI exposes it', () => {

--- a/index.js
+++ b/index.js
@@ -114,10 +114,10 @@ async function checkPreconditions(log, name) {
   return { skip: false, percyDOMScript };
 }
 
-function injectPercyDOM(percyDOMScript) {
-  if (!window.PercyDOM) {
+function injectPercyDOM(win, percyDOMScript) {
+  if (!win.PercyDOM) {
     // eslint-disable-next-line no-eval
-    (0, eval)(percyDOMScript);
+    win.eval(percyDOMScript);
   }
 }
 
@@ -252,12 +252,20 @@ Cypress.Commands.add('percySnapshot', (name, options = {}) => {
       cy.document({ log: false }).then(async doc => {
         if (_skip || !_percyDOMScript) return;
 
-        injectPercyDOM(_percyDOMScript);
+        // Inject + run PercyDOM in the app-under-test realm (doc.defaultView),
+        // NOT the Cypress spec/runner frame. waitForReady takes no document
+        // argument and queries the ambient `document`;
+        // injecting via spec-realm eval made every readiness check observe the
+        // runner frame instead of the app (readySelectors timed out, the other
+        // checks silently no-op'd). serialize was unaffected only because it's
+        // passed `dom: doc` explicitly.
+        const win = doc.defaultView;
+        injectPercyDOM(win, _percyDOMScript);
 
         // Capture a stable PercyDOM reference: the page can reassign
-        // window.PercyDOM across the await below (e.g. on cy.reload in the
+        // win.PercyDOM across the await below (e.g. on cy.reload in the
         // responsive loop), so re-reading after the await is a footgun.
-        const PercyDOM = window.PercyDOM;
+        const PercyDOM = win.PercyDOM;
 
         // Readiness gate. The package.json floor pins @percy/sdk-utils to
         // 1.31.15-beta.0+, so isReadinessDisabled / getReadinessConfig are


### PR DESCRIPTION
## Bug

The PER-7348 readiness gate in `@percy/cypress` (`3.1.9-beta.0`) runs against the **wrong document** — the Cypress runner iframe, not the app under test.

`injectPercyDOM` used an indirect `(0, eval)(script)`, which executes in the **Cypress spec/runner realm**, and `PercyDOM.waitForReady()` takes **no document argument** — it queries the bundle's ambient `document`. So every readiness check observed the runner frame, not the app:

- **`readySelectors` always times out** (app elements never exist in the runner frame), then the snapshot is captured anyway after the full readiness timeout.
- `dom_stability` / `network_idle` / `image_ready` / `font_ready` / `js_idle` measure the **static runner frame** → the gate silently reports `passed: true` for the wrong document — an **effective no-op**.

`PercyDOM.serialize({ dom: doc })` is unaffected because it's handed the AUT document explicitly (so snapshots themselves are correct).

## How it was identified

Found during PER-7348 end-to-end validation of the published beta against `example-percy-cypress`: `readySelectors` snapshots timed out (8–30s) while selenium/wdio/nightwatch/python passed in ~300ms. Proven by probing realms inside the snapshot command — from the command realm `document.location` = `…/__cypress/iframes/…` and `document.querySelector('.todoapp')` = `null`, while `cy.document()` (AUT) has it; and a direct `cy.window()` → `waitForReady` (AUT realm) passed in 358ms.

## Fix

Inject and run PercyDOM in the **AUT realm** via `doc.defaultView` (`win.eval` + `win.PercyDOM`). The gate now observes the real application DOM. Single-file change in `index.js`; `serialize` still receives `dom: doc`.

## Tests

`installPercyDOMStub` previously set `window.PercyDOM` on the **spec realm** (the same wrong realm), so the suite passed while production failed. It now stubs on the **AUT window** (`cy.window()`) — matching the fix and turning these into real regression guards.

## Verification

End-to-end against `example-percy-cypress` (CLI `1.32.0-beta.4` + this fix): `readySelectors` went from a **30s timeout** to **passing in ~360ms** with real per-check diagnostics; full matrix (presets / yml / precedence / kill-switch) green.

> Independent of the puppeteer/playwright `Illegal return` fix train (`cli#2247`) — different SDK, different root cause (realm wiring, not top-level `return`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)