### PR TITLE
chore: release 3.1.9-beta.1 (PER-7348 cypress readiness realm fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/cypress",
   "description": "Cypress client library for visual testing with Percy",
-  "version": "3.1.9-beta.0",
+  "version": "3.1.9-beta.1",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-cypress",


### PR DESCRIPTION
## What
Beta release bumping `@percy/cypress` to **3.1.9-beta.1**.

Ships the PER-7348 readiness-gate **realm fix** from #1104: the gate now runs in the app-under-test window (`doc.defaultView`) instead of the Cypress runner frame, so `PercyDOM.waitForReady` queries the correct `document`. The previously published `3.1.9-beta.0` included the gate but it silently no-op'd because it ran in the wrong realm.

## ⚠️ Merge order (this PR is a draft on purpose)
1. **Merge #1104** (the fix) into master first.
2. **Rebase this branch** onto the updated master (so the published beta actually contains the fix, and the coverage validator passes on a non-stale branch).
3. Mark ready → merge → the `chore: release` merge publishes `3.1.9-beta.1` to the `beta` dist-tag.

`publishConfig.tag` is already `beta`; deps unchanged (the fix needs no `@percy/sdk-utils` bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)