### PR TITLE
chore: bump version to 3.1.9-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/cypress",
   "description": "Cypress client library for visual testing with Percy",
-  "version": "3.1.9-beta.1",
+  "version": "3.1.9-beta.2",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-cypress",


### PR DESCRIPTION
Version bump to `3.1.9-beta.2` to release the merged CORS-iframe + closed-shadow-DOM work (PER-7292).

Bumps `3.1.9-beta.1` → `3.1.9-beta.2` (next beta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)