### PR TITLE
chore: release 3.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "main": "index.js",
   "types": "types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/cypress",
   "description": "Cypress client library for visual testing with Percy",
-  "version": "3.1.9-beta.3",
+  "version": "3.1.9",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-cypress",


### PR DESCRIPTION
Promotes the PER-8053 config-merge work from `3.1.9-beta.3` to stable `3.1.9`. Config is deep-merged into serializeDOM (per-call priority); verified via the cross-SDK sanity sweep.

Note: a pre-staged **draft** `v3.1.9` release exists (no git tag yet) — publish/replace it at release time.